### PR TITLE
Fix Typos and Improve Documentation Clarity

### DIFF
--- a/covenant/continuous/src/main.rs
+++ b/covenant/continuous/src/main.rs
@@ -134,7 +134,7 @@ where
 {
     let mut retry_count = 0;
 
-    // Wait for the block to be avaliable in the HTTP provider
+    // Wait for the block to be available in the HTTP provider
     executor.wait_for_block(number).await?;
 
     loop {

--- a/node/README.md
+++ b/node/README.md
@@ -46,7 +46,7 @@ ACTOR=Operator RUST_LOG=debug ./target/debug/bitvm2-noded --bootnodes 12D3KooWKq
 
 ## Debug
 
-We can send message to the P2P network via the local node's Stdin. The message is formated as `Actor:Message`, for example, If we send a message to Operator,
+We can send message to the P2P network via the local node's Stdin. The message is formatted as `Actor:Message`, for example, If we send a message to Operator,
 
 ```bash
 Challenger: {"key": "123"}

--- a/node/src/tests.rs
+++ b/node/src/tests.rs
@@ -310,7 +310,7 @@ pub mod tests {
 
         let mut graph = operator::generate_bitvm_graph(params, disprove_scripts_bytes).unwrap();
 
-        // opeartor pre-sign
+        // operator pre-sign
         println!("\nopeartor pre-sign");
         let _ = operator::operator_pre_sign(operator_keypair, &mut graph).unwrap();
 


### PR DESCRIPTION


Description:  
This pull request addresses several minor issues across the codebase:
- Corrects a typo in a comment in `covenant/continuous/src/main.rs` ("avaliable" → "available").
- Fixes a spelling error in the documentation in `node/README.md` ("formated" → "formatted").
- Corrects a typo in a comment in `node/src/tests.rs` ("opeartor" → "operator").

These changes improve the readability and clarity of both the code and documentation. No functional code changes are introduced.
