### PR TITLE
ci: remove scheduled ci

### DIFF
--- a/.github/workflows/ci_time_consuming.yml
+++ b/.github/workflows/ci_time_consuming.yml
@@ -1,10 +1,8 @@
-name: Scheduled CI
+name: Time-consuming test
 
 on:
   push:
     branches: ["main"]
-  schedule:
-    - cron: '0 20 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Time-consuming tests will be executed when a PR is merged into the main branch, so there's no need to run them daily.