### PR TITLE
fix typo in tests.rs and Minor Doc Update

### DIFF
--- a/node/docs/API.md
+++ b/node/docs/API.md
@@ -487,7 +487,7 @@ pub enum GraphBridgePath {
 
 `ps:graph_status is map<graph_id>graph_status` ,The number of `graph_status` should correspond to the number of graphs
 for the given instance.
-If a graph for the instancce is created, the count must be greater than or equal to 1.
+If a graph for the instance is created, the count must be greater than or equal to 1.
 
 #### Graph TXN
 

--- a/node/src/tests.rs
+++ b/node/src/tests.rs
@@ -162,16 +162,16 @@ pub mod tests {
     fn broadcast_and_wait_for_confirming(
         rpc_client: &BlockingClient,
         tx: &Transaction,
-        confimations: u32,
+        confirmations: u32,
     ) {
         let pre_current_tip = rpc_client.get_height().unwrap();
         rpc_client.broadcast(tx).unwrap();
         println!("Broadcast tx: {}", tx.compute_txid());
         let mut current_tip = rpc_client.get_height().unwrap();
-        while (current_tip - pre_current_tip) < confimations {
+        while (current_tip - pre_current_tip) < confirmations {
             println!(
                 "Wait for at least {} block mined",
-                confimations - (current_tip - pre_current_tip)
+                confirmations - (current_tip - pre_current_tip)
             );
             std::thread::sleep(std::time::Duration::from_secs(1));
             current_tip = rpc_client.get_height().unwrap();


### PR DESCRIPTION


Description:  
This pull request addresses a typo in the `broadcast_and_wait_for_confirming` function within `node/src/tests.rs`, correcting "confimations" to "confirmations" throughout the function. Additionally, a minor wording update was made in the documentation (`node/docs/API.md`) for improved clarity. No functional changes were introduced beyond the typo fix and documentation improvement.