### PR TITLE
Fix typo: Change "instanct" to "instance" in API documentation

### DIFF
--- a/node/docs/API.md
+++ b/node/docs/API.md
@@ -148,7 +148,7 @@ pub enum InstanceStatus {
     L2Minted, // success
 }
 
-/// 4.instanct.amount in bitcoin sat
+/// 4.instance.amount in bitcoin sat
 ```
 
 #### Get Instance


### PR DESCRIPTION


Description:
This pull request corrects a typo in the API documentation file (API.md), changing "instanct.amount in bitcoin sat" to "instance.amount in bitcoin sat" for improved clarity and accuracy. No functional code changes are included; this is a documentation update only.