### PR TITLE
The response data format for the get_proofs/get_proof interface ...

### DIFF
--- a/crates/store/src/localdb.rs
+++ b/crates/store/src/localdb.rs
@@ -579,7 +579,7 @@ impl<'a> StorageProcessor<'a> {
         status_expect: Option<String>,
     ) -> anyhow::Result<(Vec<Node>, i64)> {
         let mut nodes_query_str =
-            "SELECT peer_id, actor, goat_addr, btc_pub_key, created_at, updated_at FROM node"
+            "SELECT peer_id, actor, goat_addr, btc_pub_key, socket_addr, created_at, updated_at FROM node"
                 .to_string();
         let mut nodes_count_str = "SELECT count(*) as total_nodes FROM node".to_string();
         let mut conditions: Vec<String> = vec![];
@@ -1827,20 +1827,20 @@ FROM graph g INNER JOIN goat_tx_record gtr ON g.graph_id = gtr.graph_id WHERE gt
             block_number: i64,
             state: String,
             proving_time: i64,
-            proof_size_b: i64,
+            proof_size: i64,
             zkm_version: String,
             created_at: i64,
             updated_at: i64,
         }
         let query = match proof_type {
             ProofType::BlockProof => {
-                "SELECT block_number, state, proving_time, proof_size_b, zkm_version, created_at, updated_at FROM block_proof WHERE block_number BETWEEN ? AND ? ORDER BY block_number ASC"
+                "SELECT block_number, state, proving_time, proof_size, zkm_version, created_at, updated_at FROM block_proof WHERE block_number BETWEEN ? AND ? ORDER BY block_number ASC"
             }
             ProofType::AggregationProof => {
-                "SELECT block_number, state, proving_time, proof_size_b, zkm_version, created_at, updated_at FROM aggregation_proof WHERE block_number BETWEEN ? AND ? ORDER BY block_number ASC"
+                "SELECT block_number, state, proving_time, proof_size, zkm_version, created_at, updated_at FROM aggregation_proof WHERE block_number BETWEEN ? AND ? ORDER BY block_number ASC"
             }
             ProofType::Groth16Proof => {
-                "SELECT block_number, state, proving_time, proof_size_b, zkm_version, created_at, updated_at FROM groth16_proof WHERE block_number BETWEEN ? AND ? ORDER BY block_number ASC"
+                "SELECT block_number, state, proving_time, proof_size, zkm_version, created_at, updated_at FROM groth16_proof WHERE block_number BETWEEN ? AND ? ORDER BY block_number ASC"
             }
         };
 
@@ -1857,7 +1857,7 @@ FROM graph g INNER JOIN goat_tx_record gtr ON g.graph_id = gtr.graph_id WHERE gt
                     v.block_number,
                     v.state,
                     v.proving_time,
-                    v.proof_size_b,
+                    v.proof_size,
                     v.zkm_version,
                     v.created_at,
                     v.updated_at,

--- a/node/docs/API.md
+++ b/node/docs/API.md
@@ -535,54 +535,78 @@ If a graph for the instance is created, the count must be greater than or equal 
 
 #### Get Proofs
 - **Endpoint**: `GET /v1/proofs/`
-- **Description**: Retrieve goat block proofs, contains: block proof,aggregation proof, groth16 proof
+- **Description**: Retrieve list goat block proofs, contains: block proof,aggregation proof, groth16 proof
 - **Query Parameters**:
     - `block_number`: the goat block height
     - `block_range`: the number block proofs need to query
     - `graph_id`: graph for locating Layer 2 block height
 - **Response**:
-  ```json
+ ```json
   {
-    "block_number": "number",
     "block_proofs": [
         {
             "block_number": "number",
-            "state": "string",
-            "proving_time": "number",
-            "total_time_to_proof": "number",
-            "proof_size": "number",
-            "zkvm_version":"string",
-            "started_at": "number",
-            "updated_at": "number"
+            "block_proof": {
+                "state": "string",
+                "proving_time": "number",
+                "total_time_to_proof": "number",
+                "proof_size": "string",
+                "zkm_version": "string",
+                "started_at": "number",
+                "updated_at": "number"
+            },
+            "aggregation_proof": {
+                "state": "string",
+                "proving_time": "number",
+                "total_time_to_proof": "number",
+                "proof_size": "string",
+                "zkm_version": "string",
+                "started_at": "number",
+                "updated_at": "number"
+            },
+            "groth16_proof": {
+                "state": "string",
+                "proving_time": "number",
+                "total_time_to_proof": "number",
+                "proof_size": "number",
+                "zkm_version": "string",
+                "started_at": "number",
+                "updated_at": "number"
+            }
+        },
+      {
+        "block_number": "number",
+        "block_proof": {
+          "state": "string",
+          "proving_time": "number",
+          "total_time_to_proof": "number",
+          "proof_size": "string",
+          "zkm_version": "string",
+          "started_at": "number",
+          "updated_at": "number"
+        },
+        "aggregation_proof": {
+          "state": "string",
+          "proving_time": "number",
+          "total_time_to_proof": "number",
+          "proof_size": "string",
+          "zkm_version": "string",
+          "started_at": "number",
+          "updated_at": "number"
+        },
+        "groth16_proof": {
+          "state": "string",
+          "proving_time": "number",
+          "total_time_to_proof": "number",
+          "proof_size": "number",
+          "zkm_version": "string",
+          "started_at": "number",
+          "updated_at": "number"
         }
-    ],
-    "aggregation_proofs": [
-        {
-            "block_number": "number",
-            "state": "string",
-            "proving_time": "number",
-            "total_time_to_proof": "number",
-            "proof_size": "number",
-            "zkvm_version":"string",
-            "started_at": "number",
-            "updated_at": "number"
-        }
-    ],
-    "groth16_proofs": [
-        {
-            "block_number": "number",
-            "state": "string",
-            "proving_time": "number",
-            "total_time_to_proof": "number",
-            "proof_size": "number",
-            "zkvm_version":"string",
-            "started_at": "number",
-            "updated_at": "number"
-        }
+      }
     ]
   }
-    
-  ```
+  ``` 
   PS: `state` proof task state value: `queued`, `proved`, `failed`;
   `proving_time` pure compute proof cast, exclude init prepare, waiting and other time cast;
   `total_time_to_proof` proof cast, clude init prepare, waiting and other time cast;
@@ -599,47 +623,41 @@ If a graph for the instance is created, the count must be greater than or equal 
 - **Response**:
   ```json
   {
-    "block_number": "number",
     "block_proofs": [
         {
             "block_number": "number",
-            "state": "string",
-            "proving_time": "number",
-            "total_time_to_proof": "number",
-            "proof_size": "number",
-            "zkvm_version":"string",
-            "started_at": "number",
-            "updated_at": "number"
-        }
-    ],
-    "aggregation_proofs": [
-        {
-            "block_number": "number",
-            "state": "string",
-            "proving_time": "number",
-            "total_time_to_proof": "number",
-            "proof_size": "number",
-            "zkvm_version":"string",
-            "started_at": "number",
-            "updated_at": "number"
-        }
-    ],
-    "groth16_proofs": [
-        {
-            "block_number": "number",
-            "state": "string",
-            "proving_time": "number",
-            "total_time_to_proof": "number",
-            "proof_size": "number",
-            "zkvm_version":"string",
-            "started_at": "number",
-            "updated_at": "number"
+            "block_proof": {
+                "state": "string",
+                "proving_time": "number",
+                "total_time_to_proof": "number",
+                "proof_size": "string",
+                "zkm_version": "string",
+                "started_at": "number",
+                "updated_at": "number"
+            },
+            "aggregation_proof": {
+                "state": "string",
+                "proving_time": "number",
+                "total_time_to_proof": "number",
+                "proof_size": "string",
+                "zkm_version": "string",
+                "started_at": "number",
+                "updated_at": "number"
+            },
+            "groth16_proof": {
+                "state": "string",
+                "proving_time": "number",
+                "total_time_to_proof": "number",
+                "proof_size": "number",
+                "zkm_version": "string",
+                "started_at": "number",
+                "updated_at": "number"
+            }
         }
     ]
   }
- 
   ```
-  PS:  `block_proofs`,`aggregation_proofs`,`groth16_proofs` contains one or zero item
+  PS:  `block_proofs` contains one or zero item
   `state` proof task state value: `queued`, `proved`, `failed`;
   `proving_time` pure compute proof cast, exclude init prepare, waiting and other time cast;
   `total_time_to_proof` proof cast, clude init prepare, waiting and other time cast;

--- a/node/src/rpc_service/mod.rs
+++ b/node/src/rpc_service/mod.rs
@@ -23,6 +23,7 @@ use bitvm2_lib::actors::Actor;
 use http::{HeaderMap, Method, StatusCode};
 use http_body_util::BodyExt;
 use prometheus_client::registry::Registry;
+use reqwest::Client;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, UNIX_EPOCH};
 use store::localdb::LocalDB;
@@ -43,6 +44,7 @@ pub struct AppState {
     pub metrics_state: MetricsState,
     pub actor: Actor,
     pub peer_id: String,
+    pub client: Client,
 }
 
 impl AppState {
@@ -55,7 +57,8 @@ impl AppState {
         // let local_db = create_local_db(db_path).await;
         let btc_client = BTCClient::new(None, get_network());
         let metrics_state = MetricsState::new(registry);
-        Ok(Arc::new(AppState { local_db, btc_client, metrics_state, actor, peer_id }))
+        let client = Client::new();
+        Ok(Arc::new(AppState { local_db, btc_client, metrics_state, actor, peer_id, client }))
     }
 }
 

--- a/node/src/rpc_service/proof.rs
+++ b/node/src/rpc_service/proof.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ProofsQueryParams {
     pub block_number: Option<i64>,
     #[serde(default = "default_block_range")]
@@ -8,13 +8,27 @@ pub struct ProofsQueryParams {
     pub graph_id: Option<String>,
 }
 
+// impl ProofsOverview{
+//     // pub fn to_url_params() -> String{
+//     //     let mut param = vec![];
+//     //     if b
+//     // }
+// }
+
 fn default_block_range() -> i64 {
     5
 }
 
-#[derive(Debug, Serialize)]
-pub struct ProofItem {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BlockProofs {
     pub block_number: i64,
+    pub block_proof: Option<ProofItem>,
+    pub aggregation_proof: Option<ProofItem>,
+    pub groth16_proof: Option<ProofItem>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProofItem {
     pub state: String,
     pub proving_time: i64,
     pub total_time_to_proof: i64,
@@ -24,15 +38,12 @@ pub struct ProofItem {
     pub updated_at: i64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Proofs {
-    pub block_number: i64,
-    pub block_proofs: Vec<ProofItem>,
-    pub aggregation_proofs: Vec<ProofItem>,
-    pub groth16_proofs: Vec<ProofItem>,
+    pub block_proofs: Vec<BlockProofs>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ProofsOverview {
     pub total_blocks: i64,
     pub avg_block_proof: i64,

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -1454,7 +1454,11 @@ pub async fn run_watch_event_task(
             match monitor_events(
                 &goat_client,
                 &local_db,
-                vec![GatewayEventEntity::InitWithdraws, GatewayEventEntity::CancelWithdraws],
+                vec![
+                    GatewayEventEntity::InitWithdraws,
+                    GatewayEventEntity::CancelWithdraws,
+                    GatewayEventEntity::ProceedWithdraws,
+                ],
             )
             .await
             {


### PR DESCRIPTION
1.The response data format for the get_proofs/get_proof interface is categorized by block height; 
2.The corresponding API on Relayer nodes provides proxy query functionality.