### PR TITLE
chore(operator): remove unused std::vec import

### DIFF
--- a/crates/bitvm2-ga/src/operator/api.rs
+++ b/crates/bitvm2-ga/src/operator/api.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use crate::types::{
     Bitvm2Graph, Bitvm2GraphParameters, Groth16Proof, OperatorWotsPublicKeys,
     OperatorWotsSecretKeys, OperatorWotsSignatures, PublicInputs, VerifyingKey,


### PR DESCRIPTION
Removed the unused std::vec import from operator/api.rs. This import was not referenced anywhere in the module (all usages go through vec![] or Vec<T>), so keeping it only adds noise