### PR TITLE
fix: distinguish maintenance task errors

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -232,8 +232,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         {
             Ok(tag) => Ok(tag),
             Err(e) => {
-                tracing::error!("Watch event task error: {}", e);
-                Err("watch_error".to_string())
+                tracing::error!("Maintenance task error: {}", e);
+                Err("maintenance_error".to_string())
             }
         }
     }));


### PR DESCRIPTION
This change fixes a copy‑paste error in the maintenance task error handling. The run_maintenance_tasks path now logs a clear “Maintenance task error” message and returns a distinct maintenance_error tag instead of reusing the watch event task’s watch_error tag. This makes it easier to understand which task failed when inspecting logs and the select_all shutdown path.