### PR TITLE
fix: clarify reward amount parsing panic message

### DIFF
--- a/crates/client/src/graphs/graph_query.rs
+++ b/crates/client/src/graphs/graph_query.rs
@@ -366,10 +366,10 @@ impl WithdrawPathsEvent {
     pub fn reward_amount_sats(&self) -> i64 {
         match self {
             WithdrawPathsEvent::WithdrawHappyEvent(v) => {
-                v.reward_amount_sats.parse::<i64>().expect("fail to decode block number")
+                v.reward_amount_sats.parse::<i64>().expect("fail to decode reward amount sats")
             }
             WithdrawPathsEvent::WithdrawUnhappyEvent(v) => {
-                v.reward_amount_sats.parse::<i64>().expect("fail to decode block number")
+                v.reward_amount_sats.parse::<i64>().expect("fail to decode reward amount sats")
             }
         }
     }


### PR DESCRIPTION
Update the panic message in WithdrawPathsEvent::reward_amount_sats to explicitly mention a failure decoding the reward amount in sats instead of a block number.