### PR TITLE
fix: avoid cloning cosmos block

### DIFF
--- a/crates/state-chain/src/state_chain.rs
+++ b/crates/state-chain/src/state_chain.rs
@@ -101,7 +101,7 @@ impl StateChainState {
             }
             self.evm_block_height += 1;
             self.latest_evm_block_hash = current_block_hash;
-            self.latest_cosmos_block = block.cosmos_block.clone();
+            self.latest_cosmos_block = block.cosmos_block;
         }
     }
 }


### PR DESCRIPTION
Removed the unnecessary clone when storing the latest cosmos block, since the loop already owns the block; this avoids extra allocation and keeps ownership flow cleaner.