### PR TITLE
fix: correct mock get_tx_receipt log

### DIFF
--- a/crates/client/src/goat_chain/mock_goat_adaptor.rs
+++ b/crates/client/src/goat_chain/mock_goat_adaptor.rs
@@ -79,7 +79,7 @@ impl ChainAdaptor for MockAdaptor {
     }
 
     async fn get_tx_receipt(&self, tx_hash: &str) -> anyhow::Result<Option<TransactionReceipt>> {
-        info!("call is_tx_execute_success");
+        info!("call get_tx_receipt");
         Ok(if let Ok(tx_receipt) = self.tx_receipts.lock() {
             tx_receipt.get(tx_hash).cloned()
         } else {


### PR DESCRIPTION
Updated the mock adaptor log to reflect the actual get_tx_receipt call, avoiding confusion during debugging and aligning the message with the method name.